### PR TITLE
Remove phantomjs from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,22 +14,6 @@ RUN apt-get install -y libqt4-webkit libqt4-dev xvfb
 # for a JS runtime
 RUN apt-get install -y nodejs
 
-ENV PHANTOMJS_VERSION 1.9.7
-
-# Commands
-RUN \
-  apt-get install -y git wget libfreetype6 libfontconfig bzip2 && \
-  mkdir -p /srv/var && \
-  wget -q --no-check-certificate -O /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 && \
-  tar -xjf /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C /tmp && \
-  rm -f /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 && \
-  mv /tmp/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/ /srv/var/phantomjs && \
-  ln -s /srv/var/phantomjs/bin/phantomjs /usr/bin/phantomjs && \
-  git clone https://github.com/n1k0/casperjs.git /srv/var/casperjs && \
-  ln -s /srv/var/casperjs/bin/casperjs /usr/bin/casperjs && \
-  apt-get autoremove -y && \
-  apt-get clean all
-
 ENV APP_HOME /myapp
 ENV BUNDLE_PATH /cache
 


### PR DESCRIPTION
The installation of phantom is failing, and causing problems when
building docker containers for this repo.

This has been reproduced on two machines, and as far as I can tell
phantomjs is not needed